### PR TITLE
Split on entity name for Sensu alerts

### DIFF
--- a/lib/influx.rb
+++ b/lib/influx.rb
@@ -101,6 +101,9 @@ module Influx
       incidents.map { |incident|
         next if incident['incident_key'].nil?
         entity, check = incident['incident_key'].split(':', 2)
+        if check == ''
+          entity, check = entity.split('/')
+        end
         {
           'count'  => incident['count'],
           'entity' => entity,
@@ -181,6 +184,9 @@ module Influx
       incidents.map { |incident|
         next if incident['incident_key'].nil?
         entity, check = incident['incident_key'].split(':', 2)
+        if check == ''
+          entity, check = entity.split('/')
+        end
         {
           'count'  => incident['count'],
           'entity' => entity,


### PR DESCRIPTION
Sensu alerts don't list checks seperately. They are in the format host/check. Let's split them.
